### PR TITLE
WARP-10 Add BepInEx data to analytics output

### DIFF
--- a/src/app/api/cron/daily-metrics/route.ts
+++ b/src/app/api/cron/daily-metrics/route.ts
@@ -1,86 +1,12 @@
 import { NextResponse } from "next/server";
 import { getAllMods, downloadEntryExists, addDownloadEntry } from "@/db";
 import { getPackageMetrics } from "@/lib/thunderstore";
-import { getDownloadMetrics, type ModMetric } from "@/lib/metrics";
-import { fetchUsageSummary, type UsageSummary } from "@/lib/analytics";
-import { sendEmbed, type DiscordEmbed, type EmbedField } from "@/lib/discord";
+import { getDownloadMetrics } from "@/lib/metrics";
+import { fetchUsageSummary } from "@/lib/analytics";
+import { sendEmbed } from "@/lib/discord";
+import { buildCombinedEmbed } from "@/lib/dailyMetricsEmbed";
 
 export const maxDuration = 60;
-
-// Maps Thunderstore "{author}.{name}" to BepInEx modId when they differ
-const THUNDERSTORE_TO_MODID: Record<string, string> = {
-  "warpalicious.Procedural_Roads": "warpalicious.ProceduralRoads",
-};
-
-function buildCombinedEmbed(
-  date: string,
-  downloads: ModMetric[],
-  usage: UsageSummary | null
-): DiscordEmbed {
-  // Key by modId (e.g. "warpalicious.More_World_Locations_AIO") to match across datasets
-  const usageById = new Map<string, UsageSummary["mods"][number]>();
-  if (usage) {
-    for (const mod of usage.mods) {
-      usageById.set(mod.modId, mod);
-    }
-  }
-
-  const fields: EmbedField[] = [];
-  let totalDownloads = 0;
-
-  for (const mod of downloads) {
-    totalDownloads += mod.change;
-    const thunderstoreId = `${mod.author}.${mod.name}`;
-    const modId = THUNDERSTORE_TO_MODID[thunderstoreId] ?? thunderstoreId;
-    const usageMod = usageById.get(modId);
-    const displayName = usageMod?.displayName ?? mod.name;
-
-    let value = `+${mod.change.toLocaleString()} downloads`;
-    if (usageMod) {
-      const versionLines = usageMod.versions
-        .map((v) => `v${v.version}: ${v.users}`)
-        .join(" · ");
-      value += ` · ${usageMod.dau} unique users\n${versionLines}`;
-      usageById.delete(modId);
-    }
-
-    fields.push({ name: displayName, value, inline: true });
-  }
-
-  // Add any usage-only mods not matched by downloads
-  for (const [, mod] of usageById) {
-    const versionLines = mod.versions
-      .map((v) => `v${v.version}: ${v.users}`)
-      .join(" · ");
-    fields.push({
-      name: mod.displayName,
-      value: `${mod.dau} unique users\n${versionLines}`,
-      inline: true,
-    });
-  }
-
-  if (fields.length === 0) {
-    fields.push({
-      name: "No data",
-      value: "No analytics data available.",
-      inline: false,
-    });
-  }
-
-  const footerParts: string[] = [];
-  footerParts.push(`+${totalDownloads.toLocaleString()} downloads`);
-  if (usage) {
-    footerParts.push(`${usage.totalUniqueUsers} unique users`);
-  }
-
-  return {
-    title: `Daily Analytics Report — ${date}`,
-    color: 0x5865f2,
-    fields,
-    footer: { text: footerParts.join(" · ") },
-    timestamp: new Date().toISOString(),
-  };
-}
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,6 +3,11 @@ export interface UsageVersion {
   users: number;
 }
 
+export interface BepInExVersion {
+  version: string;
+  users: number;
+}
+
 export interface UsageMod {
   modId: string;
   displayName: string;
@@ -13,6 +18,7 @@ export interface UsageMod {
 export interface UsageSummary {
   date: string;
   totalUniqueUsers: number;
+  bepInExVersions?: BepInExVersion[];
   mods: UsageMod[];
 }
 

--- a/src/lib/dailyMetricsEmbed.ts
+++ b/src/lib/dailyMetricsEmbed.ts
@@ -1,0 +1,94 @@
+import type { UsageSummary } from "@/lib/analytics";
+import type { DiscordEmbed, EmbedField } from "@/lib/discord";
+import type { ModMetric } from "@/lib/metrics";
+
+// Maps Thunderstore "{author}.{name}" to BepInEx modId when they differ
+const THUNDERSTORE_TO_MODID: Record<string, string> = {
+  "warpalicious.Procedural_Roads": "warpalicious.ProceduralRoads",
+};
+
+function formatVersionCounts(versions: { version: string; users: number }[]): string {
+  if (versions.length === 0) {
+    return "No version data";
+  }
+
+  return versions
+    .map((v) => `${v.version}: ${v.users.toLocaleString()} ${v.users === 1 ? "user" : "users"}`)
+    .join(" · ");
+}
+
+export function buildCombinedEmbed(
+  date: string,
+  downloads: ModMetric[],
+  usage: UsageSummary | null
+): DiscordEmbed {
+  // Key by modId (e.g. "warpalicious.More_World_Locations_AIO") to match across datasets
+  const usageById = new Map<string, UsageSummary["mods"][number]>();
+  if (usage) {
+    for (const mod of usage.mods) {
+      usageById.set(mod.modId, mod);
+    }
+  }
+
+  const fields: EmbedField[] = [];
+  let totalDownloads = 0;
+
+  if (usage?.bepInExVersions?.length) {
+    fields.push({
+      name: "BepInEx Versions",
+      value: formatVersionCounts(usage.bepInExVersions),
+      inline: false,
+    });
+  }
+
+  for (const mod of downloads) {
+    totalDownloads += mod.change;
+    const thunderstoreId = `${mod.author}.${mod.name}`;
+    const modId = THUNDERSTORE_TO_MODID[thunderstoreId] ?? thunderstoreId;
+    const usageMod = usageById.get(modId);
+    const displayName = usageMod?.displayName ?? mod.name;
+
+    const valueLines = [`Downloads: +${mod.change.toLocaleString()}`];
+    if (usageMod) {
+      valueLines.push(`Unique users: ${usageMod.dau.toLocaleString()}`);
+      valueLines.push(`Mod versions: ${formatVersionCounts(usageMod.versions)}`);
+      usageById.delete(modId);
+    }
+
+    fields.push({ name: displayName, value: valueLines.join("\n"), inline: true });
+  }
+
+  // Add any usage-only mods not matched by downloads
+  for (const [, mod] of usageById) {
+    fields.push({
+      name: mod.displayName,
+      value: [
+        `Unique users: ${mod.dau.toLocaleString()}`,
+        `Mod versions: ${formatVersionCounts(mod.versions)}`,
+      ].join("\n"),
+      inline: true,
+    });
+  }
+
+  if (fields.length === 0) {
+    fields.push({
+      name: "No data",
+      value: "No analytics data available.",
+      inline: false,
+    });
+  }
+
+  const footerParts: string[] = [];
+  footerParts.push(`+${totalDownloads.toLocaleString()} downloads`);
+  if (usage) {
+    footerParts.push(`${usage.totalUniqueUsers} unique users`);
+  }
+
+  return {
+    title: `Daily Analytics Report — ${date}`,
+    color: 0x5865f2,
+    fields,
+    footer: { text: footerParts.join(" · ") },
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary
- Add optional BepInEx version support to the modAnalytics usage summary contract consumed by modStats.
- Move daily analytics embed construction into a focused helper.
- Render BepInEx versions as a separate Discord field and label per-mod downloads, unique users, and mod versions clearly.

## Validation
- npm run build
- npx --yes tsx representative-data check for BepInEx versions, per-mod usage data, Thunderstore downloads, and null usage fallback

Linear: WARP-10
Mac resume command: codex-sync WARP-10 nexus-1